### PR TITLE
Added 'clone' workflow to wizard workflow

### DIFF
--- a/classes/class-revisr-git-callback.php
+++ b/classes/class-revisr-git-callback.php
@@ -151,6 +151,27 @@ class Revisr_Git_Callback {
 	}
 
 	/**
+	 * Callback for a successful clone.
+	 */
+	public function success_clone_repo( $output, $args ) {
+
+		// Updates the repository properties.
+		revisr()->git->is_repo 		= true;
+		revisr()->git->git_dir 		= revisr()->git->get_git_dir();
+		revisr()->git->work_tree 	= revisr()->git->get_work_tree();
+
+		// Clear out any errors.
+		Revisr_Admin::clear_transients();
+
+		// Adds an .htaccess file to the "/.git" directory to prevent public access.
+		if ( is_writable( revisr()->git->git_dir ) ) {
+			file_put_contents( revisr()->git->git_dir . DIRECTORY_SEPARATOR . '.htaccess', 'Deny from all' . PHP_EOL );
+		}
+
+		// Return true if we haven't exited already.
+		return true;
+	}
+	/**
 	 * Called if the repo initialization was successful.
 	 * Sets up the '.git/config' file for the first time.
 	 * @access public

--- a/classes/class-revisr-git.php
+++ b/classes/class-revisr-git.php
@@ -137,9 +137,15 @@ class Revisr_Git {
 	 */
 	public function check_work_tree( $dir = '' ) {
 
+		$this->is_repo = false;
+
 		// If no dir provided, use constant.
 		if ( '' === $dir ) {
 			$dir = $this->get_work_tree();
+		}
+
+		if ( ! $dir) {
+			return false;
 		}
 
 		// Definitely bail if not a directory.
@@ -154,10 +160,10 @@ class Revisr_Git {
 
 		// If not, set the is_repo flag to false.
 		if ( ! $git_toplevel ) {
-			$this->is_repo = false;
 			return false;
 		}
 
+		$this->is_repo = true;
 		return true;
 	}
 
@@ -230,7 +236,8 @@ class Revisr_Git {
 		if ( defined( 'REVISR_WORK_TREE' ) && is_dir( REVISR_WORK_TREE ) ) {
 			$work_tree = REVISR_WORK_TREE;
 		} else {
-			$work_tree = ABSPATH;
+			return null;
+			// $work_tree = ABSPATH;
 		}
 
 		// Remove trailing slash.

--- a/classes/class-revisr-git.php
+++ b/classes/class-revisr-git.php
@@ -108,10 +108,13 @@ class Revisr_Git {
 		$git_dir 	= Revisr_Admin::escapeshellarg( "--git-dir=$this->git_dir" );
 		$work_tree 	= Revisr_Admin::escapeshellarg( "--work-tree=$this->work_tree" );
 
-		// Run the command.
-		chdir( $this->work_tree );
-		exec( "$safe_path $git_dir $work_tree $safe_cmd $safe_args 2>&1", $output, $return_code );
-		chdir( $this->current_dir );
+		if( "clone" == $command ) {
+			exec( "$safe_path $safe_cmd $safe_args 2>&1", $output, $return_code );
+		} else {
+			chdir( $this->work_tree );
+			exec( "$safe_path $git_dir $work_tree $safe_cmd $safe_args 2>&1", $output, $return_code );
+			chdir( $this->current_dir );
+		}
 
 		// Process the response.
 		$response 			= new Revisr_Git_Callback();
@@ -588,6 +591,18 @@ class Revisr_Git {
 	public function init_repo() {
 		$init = $this->run( 'init', array( '.' ), __FUNCTION__ );
 		return $init;
+	}
+
+
+	/**
+	 * Clones a repository.
+	 * @access public
+	 * @param  string $dir The directory to clone the repo into.
+	 * @param  string $url The URL of the repo to clone.
+	 */
+	public function clone_repo( $dir, $url ) {
+		$clone = $this->run( 'clone', array( $url, $dir ), __FUNCTION__ );
+		return $clone;
 	}
 
 	/**

--- a/classes/class-revisr-settings-fields.php
+++ b/classes/class-revisr-settings-fields.php
@@ -158,6 +158,23 @@ class Revisr_Settings_Fields {
 	}
 
 	/**
+	 * Displays/updates the "Local Path" settings field.
+	 * @access public
+	 */
+	public function local_path_callback() {
+
+		$local_path = defined( 'REVISR_WORK_TREE' ) ? REVISR_WORK_TREE : '';
+		$local_path = str_replace( ABSPATH, '', $local_path );
+
+		printf(
+			'<input disabled type="text" id="local_path" name="revisr_remote_settings[local_path]" value="%s" class="regular-text revisr-text" placeholder="wp-content/themes/pub" />
+			<p class="description revisr-description">%s</p>',
+			$local_path,
+			__( 'The folder that is managed by git.', 'revisr' )
+		);
+	}
+
+	/**
 	 * Displays/updates the "Automatic Backups" settings field.
 	 * @access public
 	 */

--- a/classes/class-revisr-settings-fields.php
+++ b/classes/class-revisr-settings-fields.php
@@ -163,12 +163,12 @@ class Revisr_Settings_Fields {
 	 */
 	public function local_path_callback() {
 
-		$local_path = defined( 'REVISR_WORK_TREE' ) ? REVISR_WORK_TREE : '';
-		$local_path = str_replace( ABSPATH, '', $local_path );
+		$local_path = revisr()->git->work_tree;
 
 		printf(
 			'<input disabled type="text" id="local_path" name="revisr_remote_settings[local_path]" value="%s" class="regular-text revisr-text" placeholder="wp-content/themes/pub" />
-			<p class="description revisr-description">%s</p>',
+			<p class="description revisr-description">%s</p>
+			<button>Reninitialize</button>',
 			$local_path,
 			__( 'The folder that is managed by git.', 'revisr' )
 		);

--- a/classes/class-revisr-settings.php
+++ b/classes/class-revisr-settings.php
@@ -91,6 +91,13 @@ class Revisr_Settings {
         	'revisr_general_settings'
     	);
         add_settings_field(
+        	'local_path',
+        	__( 'Local Path', 'revisr'),
+        	array( $this->settings_fields, 'local_path_callback' ),
+        	'revisr_general_settings',
+        	'revisr_general_settings'
+        );
+        add_settings_field(
         	'gitignore',
         	__( 'Files/Directories to ignore', 'revisr'),
         	array( $this->settings_fields, 'gitignore_callback' ),


### PR DESCRIPTION
This adds the 'clone' workflow to the wizard workflow.

Start with the plugin activated, but not setup.

Select 'Yes, clone an existing repository'
<img width="581" alt="image" src="https://user-images.githubusercontent.com/146530/222771838-dd0f07c6-2968-4cbc-9cb1-c0ff9af8534e.png">

Enter the (https) path to a git repository.  (currently you can leave the field blank to default to the WordPress.com free themes repository)
Enter the path the repository should be checked out to. (currently you can leave the field blank to default to a `/pub` directory in the `wp-content/themes` directory)

<img width="535" alt="image" src="https://user-images.githubusercontent.com/146530/222772315-0abfbd97-8367-4d59-8f8f-75f37986ad15.png">

Once the assets are downloaded you will be shown a success message and the plugin will work against the newly cloned repository with the URL cloned from setup as the `origin`;

<img width="570" alt="image" src="https://user-images.githubusercontent.com/146530/222773327-c863c94d-fb44-4f8d-ae0c-8c94dcc3d099.png">

<img width="1761" alt="image" src="https://user-images.githubusercontent.com/146530/222773533-338269fb-d0ea-4afe-bf8d-ffbe763ee148.png">

If the default values were used to clone with then all of the WordPress.com Free Themes should be available.

<img width="1900" alt="image" src="https://user-images.githubusercontent.com/146530/222774333-bb343c86-3879-4e0d-a0c3-5453116026e6.png">

And you should be able to switch to another branch

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/146530/222774753-71a55207-a156-4a32-8293-239a31131155.png">

<img width="451" alt="image" src="https://user-images.githubusercontent.com/146530/222775554-57a54b7e-cfff-44a1-82da-da7e039beabd.png">

